### PR TITLE
Fix `manifest.json` to comply with current requirements.

### DIFF
--- a/custom_components/luxor/manifest.json
+++ b/custom_components/luxor/manifest.json
@@ -1,7 +1,7 @@
 {
   "codeowners": ["@dcramer"],
   "config_flow": true,
-  "description": "Integration with the Luxor lighting system.",
+  "dependencies": [],
   "documentation": "https://github.com/dcramer/hass-luxor",
   "domain": "luxor",
   "iot_class": "local_polling",

--- a/custom_components/luxor/manifest.json
+++ b/custom_components/luxor/manifest.json
@@ -1,14 +1,14 @@
 {
-  "domain": "luxor",
-  "name": "FXLuminaire Luxor",
+  "codeowners": ["@dcramer"],
+  "config_flow": true,
   "description": "Integration with the Luxor lighting system.",
   "documentation": "https://github.com/dcramer/hass-luxor",
+  "domain": "luxor",
   "iot_class": "local_polling",
   "issue_tracker": "https://github.com/dcramer/hass-luxor/issues",
-  "version": "0.0.0",
-  "config_flow": true,
-  "codeowners": ["@dcramer"],
+  "name": "FXLuminaire Luxor",
   "requirements": [
     "luxor-openapi-asyncio==0.1.0"
-  ]
+  ],
+  "version": "0.0.0"
 }

--- a/hacs.json
+++ b/hacs.json
@@ -1,10 +1,6 @@
 {
     "name": "FXLuminaire Luxor",
-    "hacs": "1.6.0",
-    "domains": [
-        "light",
-        "scene"
-    ],
+    "hacs": "1.25.0",
     "render_readme": true,
     "homeassistant": "0.118.0"
 }


### PR DESCRIPTION
Sorts and updates `manifest.json` to bring it up to [spec](https://developers.home-assistant.io/docs/creating_integration_manifest/).  There have been changes to the `manifest.json` file since this integration was created.

I have not tested this, but this probably addresses what is raised in #3.