### PR TITLE
Update Test Environment

### DIFF
--- a/.github/workflows/pull.yml
+++ b/.github/workflows/pull.yml
@@ -33,13 +33,18 @@ jobs:
   tests:
     runs-on: "ubuntu-latest"
     name: Run tests
+    strategy:
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
     steps:
       - name: Check out code from GitHub
         uses: "actions/checkout@v2"
       - name: Setup Python
         uses: "actions/setup-python@v1"
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
       - name: Install requirements
         run: python3 -m pip install -r requirements_test.txt
       - name: Run tests

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -36,13 +36,18 @@ jobs:
   tests:
     runs-on: "ubuntu-latest"
     name: Run tests
+    strategy:
+      matrix:
+        python-version:
+          - "3.9"
+          - "3.10"
     steps:
       - name: Check out code from GitHub
         uses: "actions/checkout@v2"
       - name: Setup Python
         uses: "actions/setup-python@v1"
         with:
-          python-version: "3.8"
+          python-version: ${{ matrix.python-version }}
       - name: Install requirements
         run: python3 -m pip install -r requirements_test.txt
       - name: Run tests

--- a/requirements_test.txt
+++ b/requirements_test.txt
@@ -1,2 +1,2 @@
-pytest-homeassistant-custom-component==0.4.0
+pytest-homeassistant-custom-component==0.11.16
 luxor-openapi-asyncio==0.1.0


### PR DESCRIPTION
This has GitHub Actions run with Python 3.9 and 3.10, the two versions that are supported by Home Assistant currently.  It also updates `pytest-homeassistant-custom-component` to something much newer such that it actually finds working dependencies.