### PR TITLE
Update for Home Assistant 2023.5.0

### DIFF
--- a/custom_components/luxor/__init__.py
+++ b/custom_components/luxor/__init__.py
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
     controller = LuxorController(api_client=api_client, name=api_response.controller)
     hass.data[DOMAIN][entry.entry_id] = controller
 
-    device_registry = await dr.async_get_registry(hass)
+    device_registry = dr.async_get(hass)
     device_registry.async_get_or_create(
         identifiers={(DOMAIN, controller.name)},
         config_entry_id=entry.entry_id,


### PR DESCRIPTION
The hass-luxor custom component stopped working in Home Assistant 2023.5.0 and the root problem is that async_get_registry() was removed. Turns out that and async_get() is the replacement. For more information see

 https://community.home-assistant.io/t/error-async-get-registry-after-core-2023-5-0/

Manually tested that this makes hass-luxor work again on 2023.5.0.