### PR TITLE
Update lights when coordinator data changes and add configuration for scanning intervals

### DIFF
--- a/custom_components/luxor/config_flow.py
+++ b/custom_components/luxor/config_flow.py
@@ -11,8 +11,12 @@ from pprint import pprint
 
 from .const import (
     CONF_HOST,
+    CONF_GROUP_INTERVAL,
+    CONF_THEME_INTERVAL,
     DOMAIN,
     PLATFORMS,
+    DEFAULT_GROUP_INTERVAL,
+    DEFAULT_THEME_INTERVAL,
 )
 
 
@@ -42,6 +46,8 @@ class LuxorFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
         user_input = {}
         # Provide defaults for form
         user_input[CONF_HOST] = ""
+        user_input[CONF_GROUP_INTERVAL] = DEFAULT_GROUP_INTERVAL
+        user_input[CONF_THEME_INTERVAL] = DEFAULT_THEME_INTERVAL
 
         return await self._show_config_form(user_input)
 
@@ -52,6 +58,8 @@ class LuxorFlowHandler(config_entries.ConfigFlow, domain=DOMAIN):
             data_schema=vol.Schema(
                 {
                     vol.Required(CONF_HOST, default=user_input[CONF_HOST]): str,
+                    vol.Required(CONF_GROUP_INTERVAL, default=user_input[CONF_GROUP_INTERVAL]): vol.All(vol.Coerce(int), vol.Range(min=5)),
+                    vol.Required(CONF_THEME_INTERVAL, default=user_input[CONF_THEME_INTERVAL]): vol.All(vol.Coerce(int), vol.Range(min=60))
                 }
             ),
             errors=self._errors,

--- a/custom_components/luxor/const.py
+++ b/custom_components/luxor/const.py
@@ -12,9 +12,13 @@ PLATFORMS = [LIGHT, SCENE]
 
 # Configuration and options
 CONF_HOST = "host"
+CONF_GROUP_INTERVAL = "group_interval"
+CONF_THEME_INTERVAL = "theme_interval"
 
 # Defaults
 DEFAULT_NAME = DOMAIN
+DEFAULT_GROUP_INTERVAL = 60
+DEFAULT_THEME_INTERVAL = 600
 
 # How long to wait to actually do the refresh after requesting it.
 # We wait some time so if we control multiple lights, we batch requests.

--- a/custom_components/luxor/scene.py
+++ b/custom_components/luxor/scene.py
@@ -21,12 +21,11 @@ from .const import (
     DOMAIN,
     SCENE,
     REQUEST_REFRESH_DELAY,
+    CONF_THEME_INTERVAL,
+    DEFAULT_THEME_INTERVAL,
 )
 
 _LOGGER = logging.getLogger(__name__)
-
-SCAN_INTERVAL = timedelta(seconds=600)
-
 
 async def async_setup_entry(hass, entry, async_add_entities):
     controller = hass.data[DOMAIN][entry.entry_id]
@@ -36,7 +35,7 @@ async def async_setup_entry(hass, entry, async_add_entities):
         _LOGGER,
         name="{}_{}".format(DOMAIN, SCENE),
         update_method=partial(async_fetch_scenes, controller),
-        update_interval=SCAN_INTERVAL,
+        update_interval=timedelta(seconds=entry.data.get(CONF_THEME_INTERVAL, DEFAULT_THEME_INTERVAL)),
         request_refresh_debouncer=Debouncer(
             hass, _LOGGER, cooldown=REQUEST_REFRESH_DELAY, immediate=True
         ),

--- a/custom_components/luxor/translations/en.json
+++ b/custom_components/luxor/translations/en.json
@@ -5,7 +5,9 @@
                 "title": "Luxor",
                 "description": "Integration with FXLuminaire's Luxor lighting system.",
                 "data": {
-                    "host": "Host"
+                    "host": "Host",
+                    "group_interval": "Light Update Interval (sec)",
+                    "theme_interval": "Scene Update Interval (sec)"
                 }
             }
         },


### PR DESCRIPTION
I didn't see any mechanism for the state of the lights to get updated when the coordinator receives new data. I updated the light entities to pull their data from the coordinator. I also added configuration options for the intervals to fetch group and theme states.