### PR TITLE
create separate config instance and change max pool configuration

### DIFF
--- a/custom_components/luxor/__init__.py
+++ b/custom_components/luxor/__init__.py
@@ -27,9 +27,9 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         hass.data.setdefault(DOMAIN, {})
 
     host = entry.data.get(CONF_HOST)
-    api_client = luxor_openapi_asyncio.ApiClient(
-        luxor_openapi_asyncio.Configuration(host="http://{}".format(host))
-    )
+    api_client_config = luxor_openapi_asyncio.Configuration(host="http://{}".format(host))
+    api_client_config.connection_pool_maxsize = 1
+    api_client = luxor_openapi_asyncio.ApiClient(api_client_config)
 
     api_instance = controller_api.ControllerApi(api_client)
 


### PR DESCRIPTION
Update the API Client setup to separate out configuration enabling us to change the connection_pool_maxsize. This parameter defaults to 100 in the Luxor API. Given these are little micro-controllers on a landscape lighting controller, this appears to be causing disconnects when too many api calls are made.

Per the Luxor Open API documents, setting this to a small value will queue the requests and send them automatically so this setting should be safe. I've tested this with multiple groups being changed at the same time by adding those Luxor groups to a card, changing the on/off toggle in the header of the home-assistant card and it appears things are updating and working properly.

This Closes #10 