### PR TITLE
Fix: use async_forward_entry_setups to support HA 2024+

### DIFF
--- a/custom_components/luxor/__init__.py
+++ b/custom_components/luxor/__init__.py
@@ -49,11 +49,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry):
         name=controller.name,
     )
 
-    for platform in PLATFORMS:
-        hass.async_add_job(
-            hass.config_entries.async_forward_entry_setup(entry, platform)
-        )
-
+    await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
     entry.add_update_listener(async_reload_entry)
     return True
 


### PR DESCRIPTION
Fixes ```AttributeError: 'ConfigEntries' object has no attribute 'async_forward_entry_setup'``` by switching to the correct method ```async_forward_entry_setups```, as required by newer HA versions.